### PR TITLE
[docs] temporary hack to remove autodoc type hints

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,6 @@
-sphinx>=2.0.0
+# NOTE: undo this when https://github.com/sphinx-doc/sphinx/pull/6353 is published and
+#       solution to monkey_patch_autodoc in conf.py is achieved.
+git+https://github.com/sphinx-doc/sphinx.git@2.0
+# sphinx>=2.0.0
 sphinx_rtd_theme
 pytest

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -152,10 +152,69 @@ class ProviderSummary(Autosummary):
         return super().get_table(desired_items)
 
 
+def monkey_patch_autodoc():  # noqa D100
+    # https://github.com/sphinx-doc/sphinx/issues/6361
+    # Adding temporary monkey patch solution until we discuss how to properly fix.
+    # This code is directly from
+    # https://github.com/sphinx-doc/sphinx/blob/165897a74951fb03e497d6e05496ce02e897f820/sphinx/ext/autodoc/__init__.py#L406-L408
+    def format_signature(self):  # noqa D100
+        if self.args is not None:
+            # signature given explicitly
+            args = "(%s)" % self.args
+        else:
+            # try to introspect the signature
+            try:
+                args = self.format_args()
+            except Exception as err:
+                logger.warning(__('error while formatting arguments for %s: %s') %  # noqa
+                                (self.fullname, err), type='autodoc')  # noqa
+                args = None
+
+        retann = self.retann
+
+        ################################################################################
+        # See: https://github.com/sphinx-doc/sphinx/issues/6361                        #
+        result = self.env.events.emit_firstresult('autodoc-process-signature',         #
+                                                  self.objtype, self.fullname,         #
+                                                  self.object, self.options, args,     #
+                                                  retann, self)                        #
+        ################################################################################
+        if result:
+            args, retann = result
+
+        if args is not None:
+            return args + (retann and (' -> %s' % retann) or '')
+        else:
+            return ''
+
+    from sphinx.ext.autodoc import Documenter
+    Documenter.format_signature = format_signature
+
+
+def autodoc_process_signature(app, what, name, obj, options, signature,
+                              return_annotation, documenter):
+    """
+    Remove type hints from all signatures for improved readability.
+
+    - See `autodoc-process-signature event`__
+    - See https://github.com/sphinx-doc/sphinx/issues/6361
+
+    __ http://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#event-autodoc-process-signature
+    """  # noqa E501
+    try:
+        return documenter.format_args(show_annotation=False), return_annotation
+    except:  # noqa E722
+        return None
+
+
 def setup(app):  # noqa: D103
+    monkey_patch_autodoc()
+
     app.add_css_file("custom.css")
     app.add_directive("dlistsummary", DefinitionListSummary)
     app.add_directive("availableproviders", ProviderSummary)
 
     app.add_node(Youtube, html=(visit_youtube_node, depart_youtube_node))
     app.add_directive("youtube", YoutubeDirective)
+
+    app.connect("autodoc-process-signature", autodoc_process_signature)

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,3 +42,7 @@ ignore_missing_imports = true
 
 [mypy-youtube]
 ignore_missing_imports = true
+
+# NOTE: see docs/requirements.txt, this will not be needed in future.
+[mypy-sphinx.ext.autodoc]
+ignore_missing_imports = true


### PR DESCRIPTION
**Before**:

![before_hacks](https://user-images.githubusercontent.com/5871461/57674139-350b6800-75d3-11e9-918c-234dac5a3e87.png)

**After**:

![after_hacks](https://user-images.githubusercontent.com/5871461/57674155-3f2d6680-75d3-11e9-984a-b6fc45c8c4a6.png)

Now you can actually read it...

See comments in `conf.py`, this is a temporary solution that I intend to fix in sphinx proper after some discussion about what is wanted.