### PR TITLE
fix python 3.5 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,19 @@ branches:
 matrix:
   include:
     - os: linux
-      language: python
-      python: 3.5
+      # NOTE: using language: generic on xenial to specifically get 3.5.2, which
+      # does not have NoReturn in typing.  Acquiring 3.5.0 on Ubuntu is
+      # challenging even to build from source due to OpenSSL ABI changes.
+      language: generic
+      addons:
+        apt:
+          packages:
+            - python3.5
+            - python3.5-dev
+            - python3.5-venv
+      before_install:
+        - python3 -m venv venv
+        - source venv/bin/activate
       env: PY=3.5
     - os: linux
       language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,25 @@ branches:
 matrix:
   include:
     - os: linux
+      language: python
+      python: 3.7
+      services:
+        - docker
+      before_install:
+        - docker pull python:3.5.0
+        - docker run -itd --name py350 python:3.5.0 /bin/sh
+        - docker cp . py350:/data
+      install:
+        - docker exec py350 pip install tox
+      script:
+        - docker exec --workdir /data py350 tox -e py -- --cov-report xml:coverage.xml --cov
+        - docker cp py350:/data/coverage.xml .
+        - docker stop py350
+      after_success:
+        - pip install codecov
+        - codecov --required -X gcov -f coverage.xml --name "[Travis] docker-py3.5.0"
+      env: PY=3.5.0
+    - os: linux
       # NOTE: using language: generic on xenial to specifically get 3.5.2, which
       # does not have NoReturn in typing.  Acquiring 3.5.0 on Ubuntu is
       # challenging even to build from source due to OpenSSL ABI changes.

--- a/ci_exec/core.py
+++ b/ci_exec/core.py
@@ -21,7 +21,13 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import NoReturn, Optional, Union
+from typing import Optional, Union
+
+# NoReturn not available in all 3.5.
+try:
+    from typing import NoReturn
+except ImportError:
+    NoReturn = None
 
 from .colorize import Colors, Styles, colorize
 

--- a/ci_exec/provider.py
+++ b/ci_exec/provider.py
@@ -16,7 +16,13 @@
 """Mechanisms to detect a given CI provider."""
 
 import os
-from typing import Callable, List, TYPE_CHECKING
+from typing import Callable, List
+
+# TYPE_CHECKING not available in all 3.5.
+try:
+    from typing import TYPE_CHECKING
+except ImportError:
+    TYPE_CHECKING = False
 
 # mypy has trouble inferring @provider as @staticmethod right now.  The solution will
 # not likely exist for a while, there are some deeper problems with typing and


### PR DESCRIPTION
- [x] Get tests to fail on 3.5.
- [x] Condition out `NoReturn`.
- [x] Condition out `TYPE_CHECKING`.