### PR TITLE
support mypy for consuming projects

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,9 @@ setup(
         "docs", "docs.*",
         "tests", "tests.*",
     ]),
-    zip_safe=True,
+    package_data={"ci_exec": ["py.typed"]},
+    include_package_data=True,
+    zip_safe=False,
     python_requires=">=3.5",
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ commands =
     {envpython} -V -V
 
 [testenv:flake8]
+# Skipping install for flake8 is OK.
 skip_install = true
 deps =
     flake8
@@ -28,16 +29,28 @@ commands =
     pytest --flake8 -m flake8 ci_exec/ demos/ docs/ tests/
 
 [testenv:mypy]
-skip_install = true
+# To test that the py.typed gets installed correctly, we need to install.
+skip_install = false
 deps =
     mypy
     pytest-mypy
 commands =
     mypy --version
-    pytest --mypy -m mypy ci_exec/ demos/ docs/ tests/
+    pytest --mypy -m mypy ci_exec/ docs/ tests/
+    # Copy the demos directory to the temp dir, and run mypy with the current
+    # working directory as the temp dir.  Doing this to validate that the
+    # py.typed gets installed as expected.  Otherwise, consuming packages do
+    # not have the ability to run mypy :scream:
+    {envpython} -c "import shutil; \
+        shutil.rmtree('{envtmpdir}/demos', ignore_errors=True); \
+        shutil.copytree('demos', '{envtmpdir}/demos')"
+    {envpython} -c "import subprocess; \
+        subprocess.run(['mypy', '--pretty', 'demos'], \
+                       cwd='{envtmpdir}', check=True)"
 
 [testenv:lint]
-skip_install = true
+# Since mypy needs to install this needs to install too.
+skip_install = false
 deps =
     {[testenv:flake8]deps}
     {[testenv:mypy]deps}
@@ -104,7 +117,7 @@ commands =
     rm -rf dist/
     rm -rf ci_exec.egg-info/
     rm -rf .eggs/
-    rm -rf tests/.cache
-    rm -rf .mypy_cache
     find . -name "*.py[co]" -type f -exec rm -f \{\} +
     find . -name "__pycache__" -type d -exec rm -rf \{\} +
+    find . -type d -name ".cache" -exec rm -rf \{\} +
+    find . -type d -name ".mypy_cache" -exec rm -rf \{\} +

--- a/tox.ini
+++ b/tox.ini
@@ -41,9 +41,9 @@ commands =
     # working directory as the temp dir.  Doing this to validate that the
     # py.typed gets installed as expected.  Otherwise, consuming packages do
     # not have the ability to run mypy :scream:
-    {envpython} -c "import shutil; \
-        shutil.rmtree('{envtmpdir}/demos', ignore_errors=True); \
-        shutil.copytree('demos', '{envtmpdir}/demos')"
+    {envpython} -c "import shutil; import os.path as osp; \
+        shutil.rmtree(osp.join('{envtmpdir}', 'demos'), ignore_errors=True); \
+        shutil.copytree('demos', osp.join('{envtmpdir}', 'demos'))"
     {envpython} -c "import subprocess; \
         subprocess.run(['mypy', '--pretty', 'demos'], \
                        cwd='{envtmpdir}', check=True)"


### PR DESCRIPTION
Fixes #22.

- [X] Rearrange how `mypy` checks are done on the `demos/` directory so that things break.
- [X] Install `py.typed` :smirk: